### PR TITLE
fix: use sed instead of grep for macOS compatibility

### DIFF
--- a/n
+++ b/n
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-target_folder=$(pwd | grep -oP 'repos/\K[^/]+')
+target_folder=$(pwd | sed -n 's#^.*repos/\([^/]*\).*#\1#p')
 
 cd "$(dirname "$0")"
 source .env


### PR DESCRIPTION
When using `grep`, the `n` script returns an error on macOS:

```
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
	[-e pattern] [-f file] [--binary-files=value] [--color=when]
	[--context[=num]] [--directories=action] [--label] [--line-buffered]
	[--null] [pattern] [file ...]
```

Changing to `sed` seems to fix this.