### PR TITLE
fix: for macOS, force linux VM env and use patched Mailhog image

### DIFF
--- a/build-image-81.sh
+++ b/build-image-81.sh
@@ -6,7 +6,8 @@ then
     APACHE_USER="$USE_CUSTOM_APACHE_USER"
 fi
 
-docker build -t newspack-dev-81 \
+docker build --platform linux/amd64 \
+    -t newspack-dev-81 \
     --build-arg PHP_VERSION=8.1 \
     --build-arg COMPOSER_VERSION=2.2.6 \
     --build-arg NODE_VERSION=16.14.2 \

--- a/docker-compose-81.yml
+++ b/docker-compose-81.yml
@@ -32,6 +32,7 @@ services:
   ##  - The docker/logs/php directory so we can access PHP log files directly from the host file system
   ##  - The docker/bin directory for provisioning scripts
   wordpress:
+    platform: linux/amd64
     container_name: newspack_dev
     depends_on:
       - db
@@ -57,7 +58,7 @@ services:
      # - COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
       - APACHE_RUN_USER=${USE_CUSTOM_APACHE_USER:-www-data}
   mailhog:
-    image: mailhog/mailhog:latest
+    image: arjenz/mailhog:latest
     restart: always
     ports:
       - 1025:1025


### PR DESCRIPTION
This fixes Mailhog on PHP 8.1 environments in macOS. Implemented only in 8.1 scripts for now.