### PR TITLE
infer target project from repos.sh

### DIFF
--- a/bin/watch-repo.sh
+++ b/bin/watch-repo.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-source repos.sh
 CODE_PATH="/newspack-repos"
 
 if [ $# -eq 0 ]; then

--- a/n
+++ b/n
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-target_folder=$(pwd | sed -n 's#^.*repos/\([^/]*\).*#\1#p')
+source "$(dirname "${BASH_SOURCE[0]}")/bin/repos.sh"
+
+# Infer the current working project from the current folder;
+
+projects=("${newspack_plugins[@]}" "newspack-theme") # create a new list with the appended value
+target_folder=""
+
+for plugin in "${projects[@]}"; do
+    if [[ "$PWD" == *"$plugin"* ]]; then
+        target_folder=$plugin
+    fi
+done
 
 cd "$(dirname "$0")"
 source .env


### PR DESCRIPTION
Infers the current project from the current directory using the list of known repos. This gives us more flexibility and don't rely on the repos being necessarily into `newspack-docker/repos/...`