### PR TITLE
fix: snapshot

### DIFF
--- a/bin/link-repos.sh
+++ b/bin/link-repos.sh
@@ -40,6 +40,17 @@ do :
 	fi
 done
 
+for dir in "${newspack_block_theme[@]}"
+do :
+	link="$WP_PATH/themes/$dir"
+	if [ -L "${link}" ]; then
+		echo "$dir already symlinked"
+	else
+		echo "Symlinking $dir"
+		ln -s "$CODE_PATH/$dir" "$link"
+	fi
+done
+
 link="/var/www/manager-html/wp-content/plugins/newspack-manager-client"
 if [ -L "${link}" ]; then
 	echo "newspack-manager-client already symlinked"

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -23,3 +23,7 @@ newspack_themes=(
 	"newspack-sacha"
 	"newspack-scott"
 )
+
+newspack_block_theme=(
+	"newspack-theme"
+)

--- a/bin/snapshot-create.sh
+++ b/bin/snapshot-create.sh
@@ -5,7 +5,7 @@ mkdir -p $FOLDER
 
 echo Creating snapshot $1
 echo "dumping database..."
-wp db export $FOLDER/db.sql
+wp db export $FOLDER/db.sql --allow-root
 echo "Copying uploads..."
 mkdir -p $FOLDER/uploads
 cp -r /var/www/html/wp-content/uploads/* $FOLDER/uploads


### PR DESCRIPTION
Adds `--allow-root` to the snapshot-create script, to ensure that the `wp db export` command works even if the script runs the command at root permissions.

Also adds the `newspack-block-theme` to the list of symlinked themes, if it exists in the `repos` folder. It's not cloned automatically by the setup scripts.