### PR TITLE
fix: mysql startup, and some convenience fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ manager-html
 additional-sites-html
 bin/manager.private.key
 bin/manager.public.key
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The default builds using PHP 8. You can also call `./build-image-7.4.sh` or `./b
 
 ### Clone all repos
 
-This will clone all Newspack repos inside the `repos` folder
+This will clone all Newspack repos inside the `repos` folder. Assumes your host machine is authenticated with GitHub. Default git protocol is SSH. Add `-h` or `--https` to clone using HTTPS instead.
 
 ```BASH
 ./clone-repos.sh
@@ -54,6 +54,8 @@ n start
 (`n start 8.1` or `n start 7.4` will start the image with php 8.1 or 7.4 if you built them)
 
 When you are done, you can stop the containers with `n stop`.
+
+You can also stop and start in one command with `n restart` (or `n restart 8.1` or `n restart 7.4`).
 
 At this point you should be able to see your site in `http://localhost`.
 

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -10,6 +10,7 @@ newspack_plugins=(
 	"newspack-manager"
 	"newspack-manager-client"
 	"newspack-sponsors"
+	"republication-tracker-tool"
 	"super-cool-ad-inserter-plugin"
 	"newspack-multibranded-site"
 	"newspack-network"

--- a/clone-repos.sh
+++ b/clone-repos.sh
@@ -4,10 +4,32 @@ source bin/repos.sh
 
 mkdir -p repos
 
+PROTOCOL="ssh"
+
+while test $# -gt 0; do
+    case "$1" in
+        -h|--https)
+        shift
+        PROTOCOL="https"
+        ;;
+    *)
+        break
+        ;;
+    esac
+done
+
 cd repos
 for dir in "${newspack_plugins[@]}"
     do :
-        git clone git@github.com:Automattic/${dir}.git
+        if [[ $PROTOCOL = "ssh" ]]; then
+            git clone git@github.com:Automattic/${dir}.git
+        else
+            git clone https://github.com/Automattic/${dir}.git
+        fi
     done
 
-git clone git@github.com:Automattic/newspack-theme.git
+if [[ $PROTOCOL = "ssh" ]]; then
+    git clone https://github.com/Automattic/newspack-theme.git
+else
+    git clone https://github.com/Automattic/${dir}.git
+fi

--- a/docker-compose-74.yml
+++ b/docker-compose-74.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:latest
+    image: mariadb:10.8.2
     volumes:
       - ./data/newspack-dev_mysql:/var/lib/mysql
       - ./logs/newspack-dev/mysql:/var/log/mysql

--- a/docker-compose-81.yml
+++ b/docker-compose-81.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:latest
+    image: mariadb:10.8.2
     volumes:
       - ./data/newspack-dev_mysql:/var/lib/mysql
       - ./logs/newspack-dev/mysql:/var/log/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   ## We map a local directory (data/mysql) so we can have the mysql data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
-    image: mariadb:latest
+    image: mariadb:10.8.2
     volumes:
       - ./data/newspack-dev_mysql:/var/lib/mysql
       - ./logs/newspack-dev/mysql:/var/log/mysql

--- a/n
+++ b/n
@@ -45,9 +45,8 @@ require_target_folder() {
     fi
 }
 
-case $1 in
-    start)
-        file="docker-compose.yml"
+start() {
+    file="docker-compose.yml"
         if [ "$2" == "8.1" ]; then
             file="docker-compose-81.yml"
         fi
@@ -55,9 +54,21 @@ case $1 in
             file="docker-compose-74.yml"
         fi
         docker-compose -f $file up -d
+}
+stop() {
+    docker-compose down
+}
+
+case $1 in
+    start)
+        start
         ;;
     stop)
-        docker-compose down
+        stop
+        ;;
+    restart)
+        stop
+        start
         ;;
     sh)
         docker exec -it $USER_COMMAND newspack_dev /bin/bash


### PR DESCRIPTION
Pegs `mariadb` to v10.8.2 to avoid startup errors upon `docker-compose up`.

To test, run `docker-compose up` with each PHP version and ensure that the MySQL service starts and runs as expected.

Also added the following for convenience (all documented in README):

- When running `./clone-repos.sh` you can add a `-h` or `--https` flag to clone using HTTPS instead of SSH protocol
- You can now use `n restart` to run stop/start commands successively
- Added `.DS_Store` to `.gitignore` for MacOS
- Added [Republication Tracker Tool](https://github.com/Automattic/republication-tracker-tool/) to the list of repos to be cloned