### PR TITLE
Add SSL 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ RUN \
 # Enable mod_rewrite in Apache.
 RUN a2enmod rewrite
 
+# Enable SSL in Apache.
+RUN a2enmod ssl
+
 # Install requested version of PHP.
 RUN \
 	: "${PHP_VERSION:?Build argument PHP_VERSION needs to be set and non-empty.}" \
@@ -144,10 +147,17 @@ RUN chmod +x /usr/local/bin/init_apache_user && /usr/local/bin/init_apache_user
 COPY ./bin/run.sh /usr/local/bin/run
 
 # Xdebug
-RUN pecl install xdebug 
+RUN pecl install xdebug
 
 # Make our cmd script be executable.
 RUN chmod +x /usr/local/bin/run
+
+
+# Set up SSL
+# https://stackoverflow.com/a/73303983/3772847
+RUN echo "Mutex posixsem" >> /etc/apache2/apache2.conf
+COPY ./bin/ssl.sh /usr/local/bin/ssl
+RUN chmod +x /usr/local/bin/ssl && /usr/local/bin/ssl
 
 # Set the working directory for the next commands.
 WORKDIR /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN \
 # Enable mod_rewrite in Apache.
 RUN a2enmod rewrite
 
-# Enable SSL in Apache.
-RUN a2enmod ssl
+# Load the environment variables from the .env file
+COPY .env /tmp/.env
 
 # Install requested version of PHP.
 RUN \
@@ -143,16 +143,15 @@ COPY ./config/ssmtp.conf /etc/ssmtp/ssmtp.conf
 COPY ./bin/init_apache_user.sh /usr/local/bin/init_apache_user
 RUN chmod +x /usr/local/bin/init_apache_user && /usr/local/bin/init_apache_user
 
-# Copy our cmd bash script.
-COPY ./bin/run.sh /usr/local/bin/run
-
 # Xdebug
 RUN pecl install xdebug
 
-# Make our cmd script be executable.
+# Copy and make cmd script executable.
+COPY ./bin/run.sh /usr/local/bin/run
 RUN chmod +x /usr/local/bin/run
 
 # Set up SSL
+RUN a2enmod ssl
 # https://stackoverflow.com/a/73303983/3772847
 RUN echo "Mutex posixsem" >> /etc/apache2/apache2.conf
 COPY ./bin/ssl.sh /usr/local/bin/ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,6 @@ RUN pecl install xdebug
 # Make our cmd script be executable.
 RUN chmod +x /usr/local/bin/run
 
-
 # Set up SSL
 # https://stackoverflow.com/a/73303983/3772847
 RUN echo "Mutex posixsem" >> /etc/apache2/apache2.conf

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When you are done, you can stop the containers with `n stop`.
 
 You can also stop and start in one command with `n restart` (or `n restart 8.1` or `n restart 7.4`).
 
-At this point you should be able to see your site in `http://localhost`.
+At this point you should be able to see your site in `https://localhost`.
 
 #### Install WordPress
 ```BASH

--- a/README.md
+++ b/README.md
@@ -275,3 +275,11 @@ Visit `http://additional-sites.local` and you'll see a list of the existing site
 You can use the same `n` commands to interact with these sites. If you run the `n` script from inside a site's folder, it will interact with this specific site. If run it from anywhere else, it will interact with the main site.
 
 The sites live under `additional-sites-html` folder. `cd` into one of the sites folder to interact with them.
+
+### SSL
+
+A certificate will be generated, so HTTPS is available immediately. However, the CA (Certificate Authority) certificate is installed on the Docker machine, so a browser will warn about a `ERR_CERT_AUTHORITY_INVALID` error. To make the certificate recognisable on the host machine, run the following commands (for macOS):
+
+- `$ docker exec newspack_dev bash -c 'eval cat $(mkcert -CAROOT)/rootCA.pem' > rootCA.pem` to copy the CA certificate from the Docker machine
+- `$ sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" ./rootCA.pem` to trust this CA certificate (import to KeyChain). Alternatively, double-click on the .pem file.
+- remove the `rootCA.pem`, it's no longer needed

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -49,7 +49,7 @@ if [ -e $APACHE_PID_FILE ]; then
 fi
 
 echo
-echo "Open http://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
+echo "Open https://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
 echo "Open http://localhost:8025 to see Mailhog inbox."
 echo
 

--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /tmp/.env
+
 if [[ ! $(command -v mkcert) ]]; then
   echo "Installing mkcert"
   apt-get update && apt install -y wget libnss3-tools
@@ -15,16 +17,19 @@ fi
 
 CERTS_DIR="/etc/ssl/certs"
 
-if [ -f "$CERTS_DIR/localhost.pem" ]; then
-  echo "Found SSL certificate in $CERTS_DIR"
+if [ -f "$CERTS_DIR/${WP_DOMAIN}.pem" ]; then
+  echo "Found SSL certificate in $CERTS_DIR for ${WP_DOMAIN}."
 else
-  echo "Creating SSL certificate in $CERTS_DIR…"
+  echo "Creating SSL certificate in $CERTS_DIR for ${WP_DOMAIN}…"
 
-  # Create certificate for localhost.
+  # Create certificate for the domain.
   mkcert -install
-  mkcert localhost
+  mkcert ${WP_DOMAIN}
 
   mkdir -p $CERTS_DIR
-  mv localhost.pem "$CERTS_DIR/localhost.pem"
-  mv localhost-key.pem "$CERTS_DIR/localhost-key.pem"
+  mv ${WP_DOMAIN}.pem "$CERTS_DIR/${WP_DOMAIN}.pem"
+  mv ${WP_DOMAIN}-key.pem "$CERTS_DIR/${WP_DOMAIN}-key.pem"
 fi
+
+# Replace "localhost" with WP_DOMAIN in the apache config file:
+sed -i "s/localhost/${WP_DOMAIN}/g" /etc/apache2/sites-available/000-default.conf

--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ ! $(command -v mkcert) ]]; then
+  echo "Installing mkcert"
+  apt-get update && apt install -y wget libnss3-tools
+
+  LATEST_RELEASE_DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/FiloSottile/mkcert/releases" | jq -r 'first | .assets[] | select(.name | contains("linux-amd64")) | .browser_download_url')
+  printf "$LATEST_RELEASE_DOWNLOAD_URL"
+
+  wget "$LATEST_RELEASE_DOWNLOAD_URL"
+  mv mkcert-v*-linux-amd64 mkcert
+  chmod a+x mkcert
+  mv mkcert /usr/local/bin/
+fi
+
+CERTS_DIR="/etc/ssl/certs"
+
+if [ -f "$CERTS_DIR/localhost.pem" ]; then
+  echo "Found SSL certificate in $CERTS_DIR"
+else
+  echo "Creating SSL certificate in $CERTS_DIR…"
+
+  # Create certificate for localhost.
+  mkcert -install
+  mkcert localhost
+
+  mkdir -p $CERTS_DIR
+  mv localhost.pem "$CERTS_DIR/localhost.pem"
+  mv localhost-key.pem "$CERTS_DIR/localhost-key.pem"
+fi

--- a/config/apache_default
+++ b/config/apache_default
@@ -6,31 +6,51 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
+
 	ServerName localhost
 
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
 
-		<Directory /var/www/html>
-				AllowOverride All
-				Require all granted
-		</Directory>
+    <Directory /var/www/html>
+		AllowOverride All
+		Require all granted
+    </Directory>
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    # LogLevel info ssl:warn
 
-		# ErrorLog /var/log/apache-errors.log
-		# CustomLog /var/log/apache-access.log combined
+    # ErrorLog /var/log/apache-errors.log
+    # CustomLog /var/log/apache-access.log combined
 
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    # Include conf-available/serve-cgi-bin.conf
+
+</VirtualHost>
+
+<VirtualHost *:443>
+
+    ServerName localhost
+    DocumentRoot /var/www/html
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/localhost.pem
+    SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
+
+    <Directory /var/www/html>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    # ErrorLog /var/log/apache-errors.log
+    # CustomLog /var/log/apache-access.log combined
 
 </VirtualHost>
 

--- a/docker-compose-74.yml
+++ b/docker-compose-74.yml
@@ -48,7 +48,8 @@ services:
       - ./additional-sites-html:/var/www/additional-sites-html
       - ./snapshots:/snapshots
     ports:
-      - '${PORT_WORDPRESS:-80}:80'
+      - "${PORT_WORDPRESS:-80}:80"
+      - "${PORT_WORDPRESS:-443}:443"
     env_file:
       - default.env
       - .env

--- a/docker-compose-81.yml
+++ b/docker-compose-81.yml
@@ -47,7 +47,8 @@ services:
       - ./additional-sites-html:/var/www/additional-sites-html
       - ./snapshots:/snapshots
     ports:
-      - '${PORT_WORDPRESS:-80}:80'
+      - "${PORT_WORDPRESS:-80}:80"
+      - "${PORT_WORDPRESS:-443}:443"
     env_file:
       - default.env
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,8 @@ services:
       - ./additional-sites-html:/var/www/additional-sites-html
       - ./snapshots:/snapshots
     ports:
-      - '${PORT_WORDPRESS:-80}:80'
+      - "${PORT_WORDPRESS:-80}:80"
+      - "${PORT_WORDPRESS:-443}:443"
     env_file:
       - default.env
       - .env


### PR DESCRIPTION
Adds SSL support. 

Closes #3 

## How to test

1. Rebuild the Docker image (`./build-image.sh`) and spin up the whole show (`docker-compose up -d`).
2. [as described in the docs update]:
    1. `docker exec newspack_dev bash -c 'eval cat $(mkcert -CAROOT)/rootCA.pem' > rootCA.pem`
    2. (on a macOS) `sudo security add-trusted-cert -d -r trustRoot -k "/Library/Keychains/System.keychain" ./rootCA.pem`
4. Visit the site as `https://localhost` (or a custom domain with HTTPS)
5. Observe the site working as expected