### PR TITLE
feat: add virtual hosts and federated sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ additional-sites-html
 bin/manager.private.key
 bin/manager.public.key
 .DS_Store
+bin/newspack-network/nodes-keys.json
+bin/newspack-network/service-accounts.secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,9 +121,8 @@ RUN mkdir /usr/local/src/psysh \
 # Copy a default config file for an apache host.
 COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf
 COPY ./config/apache_manager /etc/apache2/sites-available/001-manager.conf
-COPY ./config/apache_additional_sites /etc/apache2/sites-available/002-additional.conf
 RUN a2ensite 001-manager.conf
-RUN a2ensite 002-additional.conf
+
 
 # Copy a default set of settings for PHP (php.ini).
 COPY ./config/php.ini /etc/php/${PHP_VERSION}/apache2/conf.d/20-jetpack-wordpress.ini
@@ -156,6 +155,11 @@ RUN a2enmod ssl
 RUN echo "Mutex posixsem" >> /etc/apache2/apache2.conf
 COPY ./bin/ssl.sh /usr/local/bin/ssl
 RUN chmod +x /usr/local/bin/ssl && /usr/local/bin/ssl
+
+# Set up additional sites support
+RUN a2enmod vhost_alias
+COPY ./config/apache_additional_sites /etc/apache2/sites-available/002-additional.conf
+RUN a2ensite 002-additional.conf
 
 # Set the working directory for the next commands.
 WORKDIR /var/www/html

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Other commands:
 * `n reset-site`: Drops the current site and creates a new one from scratch
 * `n pull`: Pull every git repository inside `repos/`
 * `sites-add`, `sites-drop`, `sites-list`: See Additional Sites section below
+* `n setup-newspack-network`: Sets up the connections of Newspack Network and Distributor plugins between all active sites
 
 ## Jurassic Ninja
 
@@ -254,18 +255,9 @@ define( 'NEWSPACK_DOCKER_SITE_URL_CLI_OVERRIDE', 'https://my-domain.my-tunnel.co
 
 If you need to run a couple of additional sites, we got you covered.
 
-You can have a number of additional sites running under `additional-sites.local`. They will live in subfolder of this local domain. For example; `additional-sites.local/site1`, `additional-sites.local/site2`, etc.
+You can have a number of additional sites running under `you-name-it.local`. They will live in their own local domain, such as `site1.local` and `another-site.local`.
 
-`n sites-add` will launch a new site in the next available spot. The site will come with Newpack already initialized and all the plugins linked. Your secrets will also be copied. It's basically the same result as running `n reset-site` for your main site.
-
-Preparation: Configure the `additional-sites.local` domain to point to your localhost by adding it to the `hosts` file.
-
-In your favorite text editor, open the `/etc/hosts` file and add a line with `127.0.0.1 additional-sites.local`. Or run the following command:
-```BASH
-echo "127.0.0.1 additional-sites.local" | sudo tee -a /etc/hosts
-```
-
-Visit `http://additional-sites.local` and you'll see a list of the existing sites and handy links to access them.
+`n sites-add $site_name` will launch a new site. The site will come with Newpack already initialized and all the plugins linked. Your secrets will also be copied. It's basically the same result as running `n reset-site` for your main site.
 
 * `n sites-list` - Lists the current existing sites
 * `n sites-drop $sitename` - Will completely erase the site and its database
@@ -276,7 +268,21 @@ You can use the same `n` commands to interact with these sites. If you run the `
 
 The sites live under `additional-sites-html` folder. `cd` into one of the sites folder to interact with them.
 
-### SSL
+## Newspack Network and Distributor
+
+If you want to play with Newspack's Federated sites features, there's a handy comment that will set everything up for you.
+
+* First, create as many sites you like with `n sites-add` (see docs above)
+* Run `n setup-newspack-network`
+* That's it!
+
+This command will:
+* Make sure Newspack Network and Distributor plugins are enable in all sites
+* Register the Nodes in the Newspack Network Hub (this will be your main site)
+* Configure the each Node with the Hub's key
+* Set up Distributor external connections between all sites
+
+## SSL
 
 A certificate will be generated, so HTTPS is available immediately. However, the CA (Certificate Authority) certificate is installed on the Docker machine, so a browser will warn about a `ERR_CERT_AUTHORITY_INVALID` error. To make the certificate recognisable on the host machine, run the following commands (for macOS):
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -6,7 +6,7 @@ SITE_TITLE=$WP_TITLE
 
 if [[ "$WP_PATH" == *"additional-sites-html"* ]]; then
     SITE_TITLE=$(echo $WP_PATH | sed -e 's/.*additional-sites-html\///' | cut -d'/' -f1)
-    DOMAIN_TO_INSTALL="additional-sites.local/$SITE_TITLE"
+    DOMAIN_TO_INSTALL="$SITE_TITLE.local"
 fi
 
 if wp --allow-root --path=$WP_PATH core is-installed; then

--- a/bin/newspack-network/connect-distributor.php
+++ b/bin/newspack-network/connect-distributor.php
@@ -1,0 +1,59 @@
+<?php
+
+$site_name = $args[0];
+$app_pass = $args[1];
+$wp_user = $args[2];
+
+$this_site = get_option('siteurl');
+
+$pt = 'dt_ext_connection';
+
+$existing_connection = get_posts(
+    [
+        'post_type' => $pt,
+        'title' => $site_name,
+        'post_status' => 'publish',
+        'posts_per_page' => 1,
+    ]
+);
+
+if ( ! empty( $existing_connection ) ) {
+    echo "Distributor Connection to $site_name already exists.\n";
+    exit;
+}
+
+$auth = [
+    'username' => $wp_user,
+    'base64_encoded' => base64_encode( $wp_user . ':' . $app_pass ),
+];
+
+$site_url = 'http://' . $site_name . '.local/wp-json/';
+
+echo "Connecting Distributor in site $this_site to $site_url\n";
+
+$post_id = wp_insert_post( [
+    'post_title' => $site_name,
+    'post_type' => $pt,
+    'post_status' => 'publish',
+] );
+
+$auth_handler = new Distributor\ExternalConnections\WordPressExternalConnection::$auth_handler_class( $auth );
+
+$connections = new Distributor\ExternalConnections\WordPressExternalConnection( get_the_title( $post_id ), esc_url_raw( wp_unslash( $site_url ) ), $post_id, $auth_handler );
+
+$meta = [
+    'dt_external_connection_type' => 'wp',
+    'dt_external_connection_allowed_roles' => [
+        'administrator',
+        'editor',
+    ],
+    'dt_external_connection_url' => $site_url,
+    'dt_external_connection_auth' => $auth,
+    'dt_external_connections' => $connections->check_connections(),
+    'dt_external_connection_check_time' => time(),
+];
+
+foreach ( $meta as $key => $value ) {
+    update_post_meta( $post_id, $key, $value );
+}
+

--- a/bin/newspack-network/create-nodes.php
+++ b/bin/newspack-network/create-nodes.php
@@ -1,0 +1,36 @@
+<?php
+
+
+$nodes = explode(',', $args[0]);
+$keys_filename = $args[1];
+$nodes_keys = file_exists( $keys_filename ) ? json_decode( file_get_contents( $keys_filename ), true ) : [];
+
+foreach( $nodes as $node ) {
+    if ( empty( $node ) ) {
+        continue;
+    }
+    $domain = $node . '.local';
+    $existing_node = Newspack_Network\Hub\Nodes::get_node_by_url( 'http://' . $domain );
+    if ( $existing_node ) {
+        echo "Node $domain already exists.\n";
+        echo "Making sure we have the secret key.\n";
+        $nodes_keys[ $node ] = $existing_node->get_secret_key();
+        continue;
+    }
+    $node_id = wp_insert_post( [
+        'post_title' => $domain,
+        'post_type' => Newspack_Network\Hub\Nodes::POST_TYPE_SLUG,
+        'post_status' => 'publish',
+    ] );
+
+    echo "Creating node $domain\n";
+
+    update_post_meta( $node_id, 'node-url', 'http://' . $domain );
+    $secret_key = Newspack_Network\Crypto::generate_secret_key();
+    update_post_meta( $node_id, 'secret-key', $secret_key );
+    $nodes_keys[ $node ] = $secret_key;
+
+}
+
+echo "Saving keys to $keys_filename.\n";
+file_put_contents( $keys_filename, json_encode( $nodes_keys ) );

--- a/bin/reset-site.sh
+++ b/bin/reset-site.sh
@@ -7,6 +7,10 @@ WP_PATH=${1:-"/var/www/html"}
 
 wp --allow-root --path="$WP_PATH" plugin install woocommerce
 wp --allow-root --path="$WP_PATH" plugin activate newspack-plugin woocommerce
+
+# TODO: Have just one copy of the plugin symnlinked to all sites
+wp --allow-root --path="$WP_PATH" plugin install https://github.com/10up/distributor/releases/download/2.0.1/distributor.zip --force
+
 wp --allow-root --path="$WP_PATH" newspack setup
 
 /var/scripts/import-secrets.sh $WP_PATH

--- a/bin/setup-newspack-network.sh
+++ b/bin/setup-newspack-network.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Create service accounts in every site
+APP_NAME="Distributor"
+SERVICE_ACCOUNTS_FILE="/var/scripts/newspack-network/service-accounts.secret"
+NODES_KEYS_FILE="/var/scripts/newspack-network/nodes-keys.json"
+NODES=""
+
+if ! wp user application-password exists 1 $APP_NAME --path=/var/www/html; then
+    wp plugin activate distributor --path=/var/www/html
+    wp plugin activate newspack-network --path=/var/www/html
+
+    echo "Setting main site as the Network Hub"
+    wp option set newspack_network_site_role hub --path=/var/www/html
+
+    echo "Creating service account for $WP_DOMAIN"
+    PASSWORD=$(wp user application-password create 1 $APP_NAME --porcelain --path=/var/www/html)
+    echo "$WP_DOMAIN:$PASSWORD" >> $SERVICE_ACCOUNTS_FILE
+else
+    echo "Service account for $WP_DOMAIN already exists"
+fi
+# Loop through subfolders of /var/www/additional-sites-html
+for site in $(ls -d /var/www/additional-sites-html/*/); do
+    wp plugin activate distributor --path=$site
+    wp plugin activate newspack-network --path=$site
+
+    # Get the site name from the path
+    site_name=$(echo $site | sed -e 's/.*additional-sites-html\///' | cut -d'/' -f1)
+
+    echo "Setting $site_name as a Network Node"
+    wp option set newspack_network_site_role node --path=$site
+
+    NODES="$NODES,$site_name"
+    # Create the service account
+    if ! wp user application-password exists 1 $APP_NAME --path=$site; then
+        echo "Creating service account for $site_name.local"
+        PASSWORD=$(wp user application-password create 1 $APP_NAME --porcelain --path=$site)
+        echo "$site_name:$PASSWORD" >> $SERVICE_ACCOUNTS_FILE
+    else
+        echo "Service account for $site_name.local already exists"
+    fi
+done
+
+# Configure Hub
+## Create all nodes and store the keys
+wp eval-file /var/scripts/newspack-network/create-nodes.php $NODES $NODES_KEYS_FILE --path=/var/www/html
+## Connect Distributor to all sites
+
+while IFS= read -r line; do
+
+    # Get the site name from the line
+    site_name=$(echo $line | cut -d':' -f1)
+
+    # skip if site_name is localhost
+    if [ "$site_name" == "localhost" ]; then
+        continue
+    fi
+
+    # Get the key from the line
+    key=$(echo $line | cut -d':' -f2)
+
+    # Connect Distributor to the site
+    wp eval-file /var/scripts/newspack-network/connect-distributor.php $site_name $key $WP_ADMIN_USER --path=/var/www/html
+
+done < $SERVICE_ACCOUNTS_FILE
+
+
+# Configure Nodes
+## Enter hub domain and key
+for site in $(ls -d /var/www/additional-sites-html/*/); do
+    # Get the site name from the path
+    site_name=$(echo $site | sed -e 's/.*additional-sites-html\///' | cut -d'/' -f1)
+
+    wp option set newspack_node_hub_url http://$WP_DOMAIN --path=$site
+    # open NODES_KEYS_FILE and get the key of this site from the json
+
+    NODE_KEY=`jq -r ".$site_name" "$NODES_KEYS_FILE"`
+    wp option set newspack_node_secret_key $NODE_KEY --path=$site
+
+    echo "Node $site_name configured"
+
+    ## Connect Distributor to all sites
+    while IFS= read -r line; do
+
+        # Get the site name from the line
+        target_site_name=$(echo $line | cut -d':' -f1)
+
+        # skip if site_name is the current site
+        if [ "$target_site_name" == "$site_name" ]; then
+            continue
+        fi
+
+        # skip if site_name is localhost
+        # TODO: The connection back to the hub is not working yet
+        if [ "$site_name" == "localhost" ]; then
+            continue
+        fi
+
+        # Get the key from the line
+        key=$(echo $line | cut -d':' -f2)
+
+        # Connect Distributor to the site
+        wp eval-file /var/scripts/newspack-network/connect-distributor.php $target_site_name $key $WP_ADMIN_USER --path=$site
+
+    done < $SERVICE_ACCOUNTS_FILE
+
+done

--- a/bin/sites-add.sh
+++ b/bin/sites-add.sh
@@ -1,43 +1,25 @@
 #!/bin/bash
 
-names=(
-    "site1"
-    "site2"
-    "site3"
-    "site4"
-    "site5"
-    "site6"
-)
+name=$1
+
 
 user="${APACHE_RUN_USER:-www-data}"
 
+if [ ! -d "/var/www/additional-sites-html/$name" ]; then
+    mkdir -p "/var/www/additional-sites-html/$name"
+    chown $user:$user "/var/www/additional-sites-html/$name"
 
-for name in "${names[@]}"; do
-    if [ ! -d "/var/www/additional-sites-html/$name" ]; then
-        mkdir -p "/var/www/additional-sites-html/$name"
-        chown $user:$user "/var/www/additional-sites-html/$name"
+    mysqladmin create $name -u root -p$MYSQL_ROOT_PASSWORD -h db
+    mysql -u root -p$MYSQL_ROOT_PASSWORD -h db -e "GRANT ALL PRIVILEGES ON $name.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' WITH GRANT OPTION; FLUSH PRIVILEGES;"
 
-        mysqladmin create $name -u root -p$MYSQL_ROOT_PASSWORD -h db
-        mysql -u root -p$MYSQL_ROOT_PASSWORD -h db -e "GRANT ALL PRIVILEGES ON $name.* TO '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+    su -c "/var/scripts/init-additional-site.sh $name" -m $user
+    su -c "/var/scripts/reset-site.sh /var/www/additional-sites-html/$name" -m $user
 
-        su -c "/var/scripts/init-additional-site.sh $name" -m $user
-        su -c "/var/scripts/reset-site.sh /var/www/additional-sites-html/$name" -m $user
-        
-        echo
-        echo "Site $name created!. Open additional-sites.local/${name}"
-        echo
-
-        break
-    fi
-done
-
-
-
-# /var/scripts/uninstall.sh
-# /var/scripts/install.sh
-
-# wp plugin install woocommerce
-# wp plugin activate newspack-plugin woocommerce
-# wp newspack setup
-
-# /var/scripts/import-secrets.sh
+    echo
+    echo "Site $name created!. Open ${name}.local"
+    echo
+else
+    echo
+    echo "Site $name already exists!"
+    echo
+fi

--- a/config/apache_additional_sites
+++ b/config/apache_additional_sites
@@ -6,11 +6,13 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
-	
-    ServerName additional-sites.local
+
+	UseCanonicalName Off
+    ServerAlias *.local
+	VirtualDocumentRoot /var/www/additional-sites-html/%1
 
 	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/additional-sites-html
+	# DocumentRoot /var/www/additional-sites-html
 
 		<Directory /var/www/additional-sites-html>
 				AllowOverride All
@@ -32,6 +34,26 @@
 	# following line enables the CGI configuration for this host only
 	# after it has been globally disabled with "a2disconf".
 	#Include conf-available/serve-cgi-bin.conf
+
+</VirtualHost>
+
+<VirtualHost *:443>
+
+    UseCanonicalName Off
+    ServerAlias *.local
+	VirtualDocumentRoot /var/www/additional-sites-html/%1
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/localhost.pem
+    SSLCertificateKeyFile /etc/ssl/certs/localhost-key.pem
+
+    <Directory /var/www/additional-sites-html>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    # ErrorLog /var/log/apache-errors.log
+    # CustomLog /var/log/apache-access.log combined
 
 </VirtualHost>
 

--- a/n
+++ b/n
@@ -106,7 +106,13 @@ case $1 in
         docker exec -it $USER_COMMAND newspack_dev sh -c "/var/scripts/setup-manager.sh"
         ;;
     sites-add)
-        docker exec -it newspack_dev sh -c "/var/scripts/sites-add.sh ${@:2}"
+        docker exec -it newspack_dev sh -c "/var/scripts/sites-add.sh $2"
+        read -p "Do you want to add this domain to your local hosts file? (Y/n): " choice
+        choice=${choice,,}
+        if [[ "$choice" != "n" ]]; then
+            echo "127.0.0.1 $2.local" | sudo tee -a /etc/hosts
+        fi
+
         ;;
     sites-list)
         docker exec -it newspack_dev sh -c "/var/scripts/sites-list.sh ${@:2}"
@@ -165,6 +171,9 @@ case $1 in
         fi
         cd ..
         done
+        ;;
+    setup-newspack-network)
+        docker exec -it $USER_COMMAND newspack_dev sh -c "/var/scripts/setup-newspack-network.sh"
         ;;
     *)
         echo Unknown command


### PR DESCRIPTION
how to test:

* Check the docs and see if you can use the `n sites-add` command
* Check that the site you created is accessible via its own local domain
* Create a bunch of sites
* Run `n setup-newspack-network`
* Confirm Distributor and Newspack Network plugins are available in all sites
* Confirm there are distributor external connections in all sites and that you can push and pull posts from one site to another
* Confirm the Nodes are registered in the Hub
* Change the "Newspack Network > Distributor Settings " Canonical URL setting in the Hub
* Go to the nodes > debug. Check that you can sync and the option will be populated in the nodes