### PR TITLE
fix: make PHP 8.1 the default for new and existing sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You only need to run this the first time you set up your env.
 ./build-image.sh
 ```
 
-The default builds using PHP 8. You can also call `./build-image-7.4.sh` or `./build-image-81.sh` to build an image with PHP 7.4 or 8.0. It's a good idea to have both.
+The default builds using PHP 8.1. You can also call `./build-image-7.4.sh` or `./build-image-80.sh` to build an image with PHP 7.4 or 8.0. It's a good idea to have both.
 
 ### Clone all repos
 
@@ -51,7 +51,7 @@ Now we are going to use the `n` script. (Tip: Create an alias in your `.bashrc` 
 n start
 ```
 
-(`n start 8.1` or `n start 7.4` will start the image with php 8.1 or 7.4 if you built them)
+(`n start 8.0` or `n start 7.4` will start the image with php 8.0 or 7.4 if you built them)
 
 When you are done, you can stop the containers with `n stop`.
 

--- a/build-image-80.sh
+++ b/build-image-80.sh
@@ -6,9 +6,10 @@ then
     APACHE_USER="$USE_CUSTOM_APACHE_USER"
 fi
 
-docker build --platform linux/amd64 \
-    -t newspack-dev-81 \
-    --build-arg PHP_VERSION=8.1 \
+docker build \
+    -t newspack-dev-8 \
+    --platform linux/amd64 \
+    --build-arg PHP_VERSION=8.0 \
     --build-arg COMPOSER_VERSION=2.2.6 \
     --build-arg NODE_VERSION=16.14.2 \
     --build-arg APACHE_RUN_USER="$APACHE_USER" \

--- a/build-image.sh
+++ b/build-image.sh
@@ -6,10 +6,9 @@ then
     APACHE_USER="$USE_CUSTOM_APACHE_USER"
 fi
 
-docker build \
-    -t newspack-dev-8 \
-    --platform linux/amd64 \
-    --build-arg PHP_VERSION=8.0 \
+docker build --platform linux/amd64 \
+    -t newspack-dev-81 \
+    --build-arg PHP_VERSION=8.1 \
     --build-arg COMPOSER_VERSION=2.2.6 \
     --build-arg NODE_VERSION=16.14.2 \
     --build-arg APACHE_RUN_USER="$APACHE_USER" \

--- a/n
+++ b/n
@@ -47,8 +47,8 @@ require_target_folder() {
 
 start() {
     file="docker-compose.yml"
-        if [ "$2" == "8.1" ]; then
-            file="docker-compose-81.yml"
+        if [ "$2" == "8.0" ]; then
+            file="docker-compose-80.yml"
         fi
         if [ "$2" == "7.4" ]; then
             file="docker-compose-74.yml"


### PR DESCRIPTION
Since PHP 8.0 is nearing end-of-life, we should make 8.1 the default going forward. I've been running with this on my local environment for a while so I think this is all that's needed to make the switch. We might want to add 8.2+ in a future PR.