### PR TITLE
Add SSL for the Manager instance; update its URL to manager.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/manager.public.key
 .DS_Store
 bin/newspack-network/nodes-keys.json
 bin/newspack-network/service-accounts.secret
+rootCA.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,4 +164,7 @@ RUN a2ensite 002-additional.conf
 # Set the working directory for the next commands.
 WORKDIR /var/www/html
 
+# Make WP CLI always run as with allow-root.
+RUN echo alias wp=\"wp --allow-root\" >> ~/.bashrc
+
 CMD ["/usr/local/bin/run"]

--- a/README.md
+++ b/README.md
@@ -241,11 +241,12 @@ Setup the manager by installing WordPress, creating the key pairs, adding the co
 n setup-manager
 ```
 
-Configure the `manager.local` domain to point to your localhost by adding it to the `hosts` file.
+Configure the `manager.com` domain to point to your localhost by adding it to the `hosts` file.
 
-In your favorite text editor, open the `/etc/hosts` file and add a line with `127.0.0.1 manager.local`. Or run the following command:
+In your favorite text editor, open the `/etc/hosts` file and add a line with `127.0.0.1 manager.com`. Or run the following command:
+
 ```BASH
-echo "127.0.0.1 manager.local" | sudo tee -a /etc/hosts
+echo "127.0.0.1 manager.com" | sudo tee -a /etc/hosts
 ```
 
 If you haven't done it yet, build the Manager Client plugin:
@@ -256,7 +257,7 @@ n build manager-client
 
 That's it!
 
-Now visit `manager.local/wp-admin`, go to Newspack Manager, and add the URL for you other site there.
+Now visit `manager.com/wp-admin`, go to Newspack Manager, and add the URL for you other site there.
 
 ### Note about the site domain when running CLI commands
 
@@ -266,7 +267,7 @@ Because of that, when running commands via CLI, the returned site url is localho
 
 Use the NEWSPACK_DOCKER_SITE_URL_CLI_OVERRIDE to override the site url for CLI commands.
 
-In your dev site (not the manager.local instance), add the following
+In your dev site (not the manager.com instance), add the following
 ```
 define( 'NEWSPACK_DOCKER_SITE_URL_CLI_OVERRIDE', 'https://my-domain.my-tunnel.com' );
 ```

--- a/bin/install-manager.sh
+++ b/bin/install-manager.sh
@@ -12,7 +12,7 @@ fi
 
 # Install WP core
 wp --allow-root core install \
-	--url=manager.local \
+	--url=manager.com \
 	--title="${WP_TITLE}" \
 	--admin_user=${WP_ADMIN_USER} \
 	--admin_password=${WP_ADMIN_PASSWORD} \
@@ -20,5 +20,5 @@ wp --allow-root core install \
 	--skip-email
 
 echo
-echo "Manager installed. Open manager.local"
+echo "Manager installed. Open manager.com"
 echo

--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * MU Plugin for the Newspack Docker development environment
  */
@@ -32,8 +32,8 @@ add_filter(
 
 /**
  * Make sure CLI commands use the correct site URL
- * This is important when communicating with manager.local, as the key is tied to the domain
- * 
+ * This is important when communicating with manager.com, as the key is tied to the domain
+ *
  * By default, the docker environment provides a dynamic site url, so you can access the site either via localhost or a tunneled domain, required for some actions.
  * Because of that, when running commands via CLI, the returned site url is localhost.
  * Use the NEWSPACK_DOCKER_SITE_URL_CLI_OVERRIDE to override the site url for CLI commands.

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -49,7 +49,8 @@ if [ -e $APACHE_PID_FILE ]; then
 fi
 
 echo
-echo "Open https://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
+echo "Main site is available at https://${WP_DOMAIN}${WP_HOST_PORT}/"
+echo "Newspack Manager site is available at https://manager.com${WP_HOST_PORT}/"
 echo "Open http://localhost:8025 to see Mailhog inbox."
 echo
 

--- a/bin/setup-manager.sh
+++ b/bin/setup-manager.sh
@@ -17,4 +17,5 @@ cd /var/www/manager-html
 wp --allow-root config set NEWSPACK_MANAGER_API_PRIVATE_KEY "$(cat /var/scripts/manager.private.key)"
 wp --allow-root plugin activate newspack-manager-client
 
-
+# For some reason, permalinks are not pretty by default. Because of this, the REST API wouldn't work.
+wp rewrite structure '/%year%/%monthnum%/%postname%/' --allow-root

--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -17,19 +17,26 @@ fi
 
 CERTS_DIR="/etc/ssl/certs"
 
-if [ -f "$CERTS_DIR/${WP_DOMAIN}.pem" ]; then
-  echo "Found SSL certificate in $CERTS_DIR for ${WP_DOMAIN}."
-else
-  echo "Creating SSL certificate in $CERTS_DIR for ${WP_DOMAIN}…"
+function create_cert_for_domain() {
+  local DOMAIN=$1
 
-  # Create certificate for the domain.
-  mkcert -install
-  mkcert ${WP_DOMAIN}
+  if [ -f "$CERTS_DIR/${DOMAIN}.pem" ]; then
+    echo "Found SSL certificate in $CERTS_DIR for ${DOMAIN}."
+  else
+    echo "Creating SSL certificate in $CERTS_DIR for ${DOMAIN}…"
 
-  mkdir -p $CERTS_DIR
-  mv ${WP_DOMAIN}.pem "$CERTS_DIR/${WP_DOMAIN}.pem"
-  mv ${WP_DOMAIN}-key.pem "$CERTS_DIR/${WP_DOMAIN}-key.pem"
-fi
+    mkdir -p $CERTS_DIR
+    cd $CERTS_DIR
+    # Create certificate for the domain.
+    mkcert ${DOMAIN}
+  fi
+}
+
+# Create the local CA.
+mkcert -install
+
+create_cert_for_domain $WP_DOMAIN
+create_cert_for_domain "manager.com"
 
 # Replace "localhost" with WP_DOMAIN in the apache config file:
 sed -i "s/localhost/${WP_DOMAIN}/g" /etc/apache2/sites-available/000-default.conf

--- a/bin/test-php.sh
+++ b/bin/test-php.sh
@@ -33,6 +33,6 @@ case $WHAT_TO_WATCH in
         cd "${CODE_PATH}/${WHAT_TO_WATCH}"
         bin/install-wp-tests.sh wp_tests root $MYSQL_ROOT_PASSWORD $MYSQL_HOST latest
         echo "Running: phpunit ${@:2}"
-        phpunit "${@:2}"
+        XDEBUG_MODE=coverage phpunit "${@:2}"
         ;;
 esac

--- a/config/apache_default
+++ b/config/apache_default
@@ -23,7 +23,7 @@
     # modules, e.g.
     # LogLevel info ssl:warn
 
-    # ErrorLog /var/log/apache-errors.log
+    ErrorLog /var/log/apache-errors.log
     # CustomLog /var/log/apache-access.log combined
 
     # For most configuration files from conf-available/, which are
@@ -49,7 +49,7 @@
         Require all granted
     </Directory>
 
-    # ErrorLog /var/log/apache-errors.log
+    ErrorLog /var/log/apache-errors.log
     # CustomLog /var/log/apache-access.log combined
 
 </VirtualHost>

--- a/config/apache_manager
+++ b/config/apache_manager
@@ -6,32 +6,51 @@
 	# match this virtual host. For the default virtual host (this file) this
 	# value is not decisive as it is used as a last resort host regardless.
 	# However, you must set it for any further virtual host explicitly.
-	
-    ServerName manager.local
 
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/manager-html
+	ServerName manager.com
 
-		<Directory /var/www/manager-html>
-				AllowOverride All
-				Require all granted
-		</Directory>
+    ServerAdmin webmaster@manager.com
+    DocumentRoot /var/www/manager-html
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+    <Directory /var/www/manager-html>
+		AllowOverride All
+		Require all granted
+    </Directory>
 
-	ErrorLog /var/log/apache-manager-errors.log
-	CustomLog /var/log/apache-manager-access.log combined
+    # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+    # error, crit, alert, emerg.
+    # It is also possible to configure the loglevel for particular
+    # modules, e.g.
+    # LogLevel info ssl:warn
 
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
+    ErrorLog /var/log/apache-errors.log
+    # CustomLog /var/log/apache-access.log combined
+
+    # For most configuration files from conf-available/, which are
+    # enabled or disabled at a global level, it is possible to
+    # include a line for only one particular virtual host. For example the
+    # following line enables the CGI configuration for this host only
+    # after it has been globally disabled with "a2disconf".
+    # Include conf-available/serve-cgi-bin.conf
+
+</VirtualHost>
+
+<VirtualHost *:443>
+
+    ServerName manager.com
+    DocumentRoot /var/www/manager-html
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/manager.com.pem
+    SSLCertificateKeyFile /etc/ssl/certs/manager.com-key.pem
+
+    <Directory /var/www/manager-html>
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog /var/log/apache-errors.log
+    # CustomLog /var/log/apache-access.log combined
 
 </VirtualHost>
 


### PR DESCRIPTION
1. Adds SSL for the manager WP instance 
2. Updates its URL to manager.com. This is needed for Google OAuth proxy, since it needs a real-looking URL. 

## How to test

1. Set up the dev environment with a manager instance, as described in the docs
2. Observe that `manager.com` is available locally and served over HTTPS