### PR TITLE
allow www-data to run commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,4 +167,7 @@ WORKDIR /var/www/html
 # Make WP CLI always run as with allow-root.
 RUN echo alias wp=\"wp --allow-root\" >> ~/.bashrc
 
+# Allow us to login and run commands as the default apache user. Not recommended for production environments!
+RUN chsh -s /bin/bash www-data
+
 CMD ["/usr/local/bin/run"]


### PR DESCRIPTION
on site-add command we want to run some scripts as the apache user, so the new sites are created with the proper file permissions.

example: `su -c "/var/scripts/reset-site.sh /var/www/additional-sites-html/$name" -m $user`

In environments using `www-data` as the apache user, this user is blocked by default for security reasons.

This PR allows log ins with the default apache user and workarounds the issue above. 