### PR TITLE
fix: build images with ARM64 architecture

### DIFF
--- a/bin/ssl.sh
+++ b/bin/ssl.sh
@@ -6,11 +6,11 @@ if [[ ! $(command -v mkcert) ]]; then
   echo "Installing mkcert"
   apt-get update && apt install -y wget libnss3-tools
 
-  LATEST_RELEASE_DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/FiloSottile/mkcert/releases" | jq -r 'first | .assets[] | select(.name | contains("linux-amd64")) | .browser_download_url')
+  LATEST_RELEASE_DOWNLOAD_URL=$(curl -s "https://api.github.com/repos/FiloSottile/mkcert/releases" | jq -r 'first | .assets[] | select(.name | contains("linux-arm64")) | .browser_download_url')
   printf "$LATEST_RELEASE_DOWNLOAD_URL"
 
   wget "$LATEST_RELEASE_DOWNLOAD_URL"
-  mv mkcert-v*-linux-amd64 mkcert
+  mv mkcert-v*-linux-arm64 mkcert
   chmod a+x mkcert
   mv mkcert /usr/local/bin/
 fi

--- a/build-image-74.sh
+++ b/build-image-74.sh
@@ -6,7 +6,7 @@ then
     APACHE_USER="$USE_CUSTOM_APACHE_USER"
 fi
 
-docker build --platform linux/amd64 \
+docker build --platform linux/arm64 \
     -t newspack-dev-74 \
     --build-arg PHP_VERSION=7.4 \
     --build-arg COMPOSER_VERSION=2.1.14 \

--- a/build-image-80.sh
+++ b/build-image-80.sh
@@ -8,7 +8,7 @@ fi
 
 docker build \
     -t newspack-dev-8 \
-    --platform linux/amd64 \
+    --platform linux/arm64 \
     --build-arg PHP_VERSION=8.0 \
     --build-arg COMPOSER_VERSION=2.2.6 \
     --build-arg NODE_VERSION=20.16.0 \

--- a/build-image.sh
+++ b/build-image.sh
@@ -6,7 +6,7 @@ then
     APACHE_USER="$USE_CUSTOM_APACHE_USER"
 fi
 
-docker build --platform linux/amd64 \
+docker build --platform linux/arm64 \
     -t newspack-dev-81 \
     --build-arg PHP_VERSION=8.1 \
     --build-arg COMPOSER_VERSION=2.2.6 \

--- a/docker-compose-74.yml
+++ b/docker-compose-74.yml
@@ -33,7 +33,7 @@ services:
   ##  - The docker/bin directory for provisioning scripts
   wordpress:
     container_name: newspack_dev
-    platform: linux/amd64
+    platform: linux/arm64
     depends_on:
       - db
     image: newspack-dev-74:latest

--- a/docker-compose-80.yml
+++ b/docker-compose-80.yml
@@ -33,7 +33,7 @@ services:
   ##  - The docker/bin directory for provisioning scripts
   wordpress:
     container_name: newspack_dev
-    platform: linux/amd64
+    platform: linux/arm64
     depends_on:
       - db
     image: newspack-dev-8:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   ##  - The docker/bin directory for provisioning scripts
   wordpress:
     container_name: newspack_dev
-    platform: linux/amd64
+    platform: linux/arm64
     depends_on:
       - db
     image: newspack-dev-81:latest


### PR DESCRIPTION
Builds Docker images using ARM64 architecture (MacOS) instead of AMD64 (Linux). Since most Automatticians use MacOS, this makes more sense as a default.

More details here: https://a8c.slack.com/archives/C04UKFHPB6U/p1707402363081729

A future enhancement could allow the user to set a flag before building the image to build with AMD64 instead.