### PR TITLE
feat: add commands to set all repos to specified branch

### DIFF
--- a/n
+++ b/n
@@ -191,10 +191,46 @@ case $1 in
         ;;
     pull)
         for dir in repos/*/; do
-        cd "$dir"
+        cd "$NABSPATH/$dir"
         if [ -d ".git" ]; then
             echo "Updating repository: $dir"
             git pull
+        fi
+        cd ..
+        done
+        ;;
+    trunk)
+        for dir in repos/*/; do
+        cd "$NABSPATH/$dir"
+        if [ -d ".git" ]; then
+            git checkout trunk || git checkout master
+            echo "Updating repository to `trunk`: $dir"
+            git pull
+            composer install && npm run build
+        fi
+        cd ..
+        done
+        ;;
+    alpha)
+        for dir in repos/*/; do
+        cd "$NABSPATH/$dir"
+        if [ -d ".git" ]; then
+            git checkout alpha
+            echo "Updating repository to `alpha`: $dir"
+            git pull
+            composer install && npm run build
+        fi
+        cd ..
+        done
+        ;;
+    release)
+        for dir in repos/*/; do
+        cd "$NABSPATH/$dir"
+        if [ -d ".git" ]; then
+            git checkout release
+            echo "Updating repository to `release`: $dir"
+            git pull
+            composer install && npm run build
         fi
         cd ..
         done


### PR DESCRIPTION
`n pull` sometimes wasn't able to `cd` into every repo directory, so this ensures that the command always references the full absolute path for each repo.

It also adds `n trunk`, `n alpha`, and `n release` commands which is similar to `n pull` but will set each repo to the specified branch and also run `composer install && npm run build` in each one. This should make it a little easier to set all repos to the same "channel" in one go.