### PR TITLE
Remove bash 4.0 syntax so mac works

### DIFF
--- a/n
+++ b/n
@@ -143,7 +143,7 @@ case $1 in
     sites-add)
         docker exec -it newspack_dev sh -c "/var/scripts/sites-add.sh $2"
         read -p "Do you want to add this domain to your local hosts file? (Y/n): " choice
-        choice=${choice,,}
+        choice=$(echo "$choice" | tr '[:upper:]' '[:lower:]')
         if [[ "$choice" != "n" ]]; then
             echo "127.0.0.1 $2.local" | sudo tee -a /etc/hosts
         fi


### PR DESCRIPTION
Macs are still on Bash 3, so I got a `${choice,,}: bad substitution` from `n sites-add`