### PR TITLE
fix: prevent WPORG updates for Newspack packages

### DIFF
--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -59,9 +59,7 @@ add_filter('auto_update_plugin', '__return_false');
 add_filter('auto_update_theme', '__return_false');
 
 /**
- * Prevent any network-based updates of Newspack software.
- * This will prevent WP from overwriting local newspack-newsletters, or any other package published
- * on WPORG in the future.
+ * Prevent any network-based updates of symlinked software.
  */
 add_filter(
 	'upgrader_pre_download',

--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -66,9 +66,14 @@ add_filter('auto_update_theme', '__return_false');
 add_filter(
 	'upgrader_pre_download',
 	function ( $reply, $package, $upgrader ) {
-		if ( stripos( $package, 'newspack' ) != false ) {
-			return new WP_Error( 'plugin_update_blocked', 'Updates for this plugin are disabled.' );
-		}
+        $plugins_dir = WP_CONTENT_DIR . '/plugins';
+        $symlinks = array_filter( glob( $plugins_dir . '/*' ), 'is_link' );
+        foreach ( $symlinks as $symlink ) {
+            $symlink_name = basename( $symlink );
+            if ( stripos( $package, $symlink_name ) != false ) {
+                return new WP_Error( 'plugin_update_blocked', 'Updates for this plugin are disabled.' );
+            }
+        }
 		return $reply;
 	},
 	1,

--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -57,3 +57,20 @@ add_filter('auto_update_plugin', '__return_false');
 
 // Stop auto-updates for themes.
 add_filter('auto_update_theme', '__return_false');
+
+/**
+ * Prevent any network-based updates of Newspack software.
+ * This will prevent WP from overwriting local newspack-newsletters, or any other package published
+ * on WPORG in the future.
+ */
+add_filter(
+	'upgrader_pre_download',
+	function ( $reply, $package, $upgrader ) {
+		if ( stripos( $package, 'newspack' ) != false ) {
+			return new WP_Error( 'plugin_update_blocked', 'Updates for this plugin are disabled.' );
+		}
+		return $reply;
+	},
+	1,
+	3
+);


### PR DESCRIPTION
Newspack Newsletters is available on WPORG plugin repository. If an update is published there, WP auto-updated will nuke the local version. In my experience, if the local version is a symlink, the update will fail, leaving a trail of destruction (empty dir instead of the symlink). This change prevents any network-based updates to Newspack packages. 

## How to test 

1. on `main` branch, make some changes in `wp-content/plugins/newspack-newsletters`, and ensure the version of this plugin is lower than the latest
1. run `wp plugin update newspack-newsletters` and observe the changes overwritten (plugin updated)
1. switch to this branch, redo the steps above, observe WP does not overwrite the files