### PR TITLE
fix(plugin-updates): stricter check in plugin updates disabling

### DIFF
--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -68,8 +68,8 @@ add_filter(
         $symlinks = array_filter( glob( $plugins_dir . '/*' ), 'is_link' );
         foreach ( $symlinks as $symlink ) {
             $symlink_name = basename( $symlink );
-            if ( stripos( $package, $symlink_name ) != false ) {
-                return new WP_Error( 'plugin_update_blocked', 'Updates for this plugin are disabled.' );
+            if ( stripos( $package, '/' . $symlink_name . '.' ) != false ) {
+                return new WP_Error( 'plugin_update_blocked', 'Updates for this plugin are disabled by Newspack Docker.' );
             }
         }
 		return $reply;

--- a/bin/newspack-docker-mu.php
+++ b/bin/newspack-docker-mu.php
@@ -64,8 +64,13 @@ add_filter('auto_update_theme', '__return_false');
 add_filter(
 	'upgrader_pre_download',
 	function ( $reply, $package, $upgrader ) {
-        $plugins_dir = WP_CONTENT_DIR . '/plugins';
-        $symlinks = array_filter( glob( $plugins_dir . '/*' ), 'is_link' );
+        if ( $upgrader instanceof Theme_Upgrader ) {
+            $package_dir = WP_CONTENT_DIR . '/themes';
+            $symlinks = array_filter( glob( $package_dir . '/*' ), 'is_link' );
+        } else {
+            $package_dir = WP_CONTENT_DIR . '/plugins';
+            $symlinks = array_filter( glob( $package_dir . '/*' ), 'is_link' );
+        }
         foreach ( $symlinks as $symlink ) {
             $symlink_name = basename( $symlink );
             if ( stripos( $package, '/' . $symlink_name . '.' ) != false ) {


### PR DESCRIPTION
Makes the check stricter by matching the name with a preceding slash and a leading dot. Otherwise, a symlinked `woocommerce` prevents the installation of anything starting with `woocommerce`. 