### PR TITLE
fix: pass args to start() in n command to correctly detect version

### DIFF
--- a/n
+++ b/n
@@ -80,14 +80,14 @@ switch_all_repos_to_branch() {
 
 case $1 in
     start)
-        start
+        start "$@"
         ;;
     stop)
         stop
         ;;
     restart)
         stop
-        start
+        start "$@"
         ;;
     sh)
         docker exec -it $USER_COMMAND newspack_dev /bin/bash

--- a/n
+++ b/n
@@ -54,7 +54,7 @@ require_target_folder() {
 
 start() {
     file="docker-compose.yml"
-        if [ "$2" == "8.1" ]; then
+        if [ "$1" == "8.1" ]; then
             file="docker-compose-81.yml"
         fi
         docker-compose -f $file up -d
@@ -80,14 +80,14 @@ switch_all_repos_to_branch() {
 
 case $1 in
     start)
-        start "$@"
+        start "${@:2}"
         ;;
     stop)
         stop
         ;;
     restart)
         stop
-        start "$@"
+        start "${@:2}"
         ;;
     sh)
         docker exec -it $USER_COMMAND newspack_dev /bin/bash


### PR DESCRIPTION
Our docs mention:
> n start 8.1 will start the image with php 8.1 if you built it

But the `start()` function of the `n` script doesn't receive CLI arguments by default, causing version-based logic to fail. This change forwards all arguments starting from the second (`"${@:2}"`), so the PHP version (e.g. `8.1`) is correctly received as `$1`, enabling proper selection of the compose file

### How to test the changes in this Pull Request:

1. Checkout the `main` branch of this repo.
2. Build the `8.3` and `8.1` images via `./build-image.sh` and `./build-image-81.sh` respectively if you haven't.
3. Start the environment via `n start 8.1`.
4. Check the active Docker image either on Docker Desktop or using the CLI: `docker ps | grep dev`.
5. Notice that it doesn't load the `-81` version.
6. Stop the environment with `n stop`.
7. Checkout this PR branch.
8. Restart the environment `n start 8.1`.
9. Notice that the correct image is now being loaded.
10. Validate that the restart command also continues working as expected.