### PR TITLE
chore: update memcached drop-in to match current sites version

### DIFF
--- a/bin/object-cache.php
+++ b/bin/object-cache.php
@@ -121,11 +121,16 @@ class WP_Object_Cache {
 
 	var $no_mc_groups = array();
 
-	var $cache       = array();
-	var $mc          = array();
-	var $default_mcs = array();
-	var $stats       = array();
-	var $group_ops   = array();
+	var $cache         = array();
+	var $mc            = array();
+	var $default_mcs   = array();
+	var $stats         = array();
+	var $group_ops     = array();
+	var $cache_hits    = 0;
+	var $cache_misses  = 0;
+	var $global_prefix = '';
+	var $blog_prefix   = '';
+	var $key_salt      = '';
 
 	var $flush_group         = 'WP_Object_Cache';
 	var $global_flush_group  = 'WP_Object_Cache_global';
@@ -142,6 +147,7 @@ class WP_Object_Cache {
 
 	var $connection_errors = array();
 
+	var $time_start = 0;
 	var $time_total = 0;
 	var $size_total = 0;
 	var $slow_op_microseconds = 0.005; // 5 ms
@@ -186,7 +192,7 @@ class WP_Object_Cache {
 
 		$this->group_ops_stats( 'add', $key, $group, $size, $elapsed, $comment );
 
-		if ( false !== $result ) {
+		if ( false !== $result || empty( $this->cache[$key][ 'found' ] ) ) {
 			$this->cache[ $key ] = [
 				'value' => $data,
 				'found' => true,


### PR DESCRIPTION
This PR updates the memcached drop-in to align with the version currently deployed on our sites.

This change also helps eliminate deprecation warnings on newer PHP versions like the ones below from local logs, which can clutter output and make it harder to notice real issues amid the noise:
```
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$cache_misses is deprecated in /wp-content/object-cache.php on line 893
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$time_start is deprecated in /wp-content/object-cache.php on line 957
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$global_prefix is deprecated in /wp-content/object-cache.php on line 882
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$blog_prefix is deprecated in /wp-content/object-cache.php on line 883
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$key_salt is deprecated in /wp-content/object-cache.php on line 815
PHP Deprecated:  Creation of dynamic property WP_Object_Cache::$cache_hits is deprecated in /wp-content/object-cache.php on line 892
```